### PR TITLE
Fix warning in newer releases of Matlab

### DIFF
--- a/@multipol/sym.m
+++ b/@multipol/sym.m
@@ -34,4 +34,4 @@ end
 
 % Use CHAR conversion routine first, should be faster
 
-s = sym(char(mp,xyzw));
+s = str2sym(char(mp,xyzw));


### PR DESCRIPTION
Fix warning since 'sym' will drop support in future Matlab releases